### PR TITLE
[codex] Add container restart policy accessors

### DIFF
--- a/src/Instances/Container.php
+++ b/src/Instances/Container.php
@@ -2,6 +2,8 @@
 
 namespace RenokiCo\PhpK8s\Instances;
 
+use RenokiCo\PhpK8s\Enums\RestartPolicy;
+
 class Container extends Instance
 {
     /**
@@ -92,6 +94,32 @@ class Container extends Instance
     public function getWorkingDir(): ?string
     {
         return $this->getAttribute('workingDir');
+    }
+
+    /**
+     * Set the restart policy for the container.
+     */
+    public function setRestartPolicy(RestartPolicy|string $policy): static
+    {
+        if ($policy instanceof RestartPolicy) {
+            $policy = $policy->value;
+        }
+
+        return $this->setAttribute('restartPolicy', $policy);
+    }
+
+    /**
+     * Get the restart policy for the container.
+     */
+    public function getRestartPolicy(): ?RestartPolicy
+    {
+        $policy = $this->getAttribute('restartPolicy');
+
+        if ($policy === null) {
+            return null;
+        }
+
+        return RestartPolicy::from($policy);
     }
 
     /**

--- a/src/Instances/Container.php
+++ b/src/Instances/Container.php
@@ -119,7 +119,7 @@ class Container extends Instance
             return null;
         }
 
-        return RestartPolicy::from($policy);
+        return RestartPolicy::tryFrom($policy);
     }
 
     /**

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -11,6 +11,8 @@ class ContainerTest extends TestCase
 {
     public function test_container_build()
     {
+        $this->assertNull(K8s::container()->getRestartPolicy());
+
         $container = K8s::container();
 
         $volume = K8s::volume()->awsEbs('vol-1234', 'ext3');
@@ -105,6 +107,10 @@ class ContainerTest extends TestCase
             ['name' => 'http', 'protocol' => 'TCP', 'containerPort' => 80],
             ['name' => 'https', 'protocol' => 'TCP', 'containerPort' => 443],
         ], $container->getPorts());
+
+        $stringPolicy = K8s::container()->setRestartPolicy('Never');
+        $this->assertEquals(RestartPolicy::NEVER, $stringPolicy->getRestartPolicy());
+
         $this->assertEquals('1Gi', $container->getMinMemory());
         $this->assertEquals('2Gi', $container->getMaxMemory());
         $this->assertEquals('500m', $container->getMinCpu());

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -2,6 +2,7 @@
 
 namespace RenokiCo\PhpK8s\Test;
 
+use RenokiCo\PhpK8s\Enums\RestartPolicy;
 use RenokiCo\PhpK8s\Instances\MountedVolume;
 use RenokiCo\PhpK8s\Instances\Probe;
 use RenokiCo\PhpK8s\K8s;
@@ -21,6 +22,7 @@ class ContainerTest extends TestCase
             ->addConfigMapRefs(['SECRET_TWO' => ['cm_ref_name', 'cm_ref_key']])
             ->addFieldRefs(['NODE_NAME' => ['spec.nodeName']])
             ->setArgs(['--test'])
+            ->setRestartPolicy(RestartPolicy::ALWAYS)
             ->addPort(80, 'TCP', 'http')
             ->addPort(443, 'TCP', 'https')
             ->setMountedVolumes([$volume->mountTo('/some/path')]);
@@ -98,6 +100,7 @@ class ContainerTest extends TestCase
         $this->assertStringEndsWith('nginx:1.23', $container->getImage());
         $this->assertEquals([], $container->getEnv([]));
         $this->assertEquals(['--test'], $container->getArgs());
+        $this->assertEquals(RestartPolicy::ALWAYS, $container->getRestartPolicy());
         $this->assertEquals([
             ['name' => 'http', 'protocol' => 'TCP', 'containerPort' => 80],
             ['name' => 'https', 'protocol' => 'TCP', 'containerPort' => 443],


### PR DESCRIPTION
## Summary

Add a real `restartPolicy` API to `Instances\Container` so container-level restart policy can be expressed without relying on magic attribute setters.

## What Changed

- added `Container::setRestartPolicy(RestartPolicy|string $policy): static`
- added `Container::getRestartPolicy(): ?RestartPolicy`
- added a unit-test assertion in `tests/ContainerTest.php` covering restart policy round-tripping

## Why

`K8sPod` already exposes a typed restart policy API, but `Instances\Container` did not. That gap forced downstream code to set the raw attribute directly even though restart policy is part of the container spec used by newer Kubernetes sidecar semantics.

This makes the container API explicit and typed, which also lets downstream projects remove local static-analysis workarounds.

## Validation

Validation was not run locally in this checkout because `/Users/chiragaggarwal/Desktop/appwrite/php-k8s/vendor` is not installed yet.

Planned checks once dependencies are installed:

- `./vendor/bin/pint --test src/Instances/Container.php tests/ContainerTest.php`
- `vendor/bin/phpunit tests/ContainerTest.php`
