### PR TITLE
[codex] Preserve raw log output for log operations

### DIFF
--- a/src/KubernetesCluster.php
+++ b/src/KubernetesCluster.php
@@ -174,6 +174,12 @@ class KubernetesCluster
         return match ($operation) {
             Operation::WATCH => $this->watchPath($path, $payload, $query),
             Operation::WATCH_LOGS => $this->watchLogsPath($path, $payload, $query),
+            Operation::LOG => (string) $this->call(
+                $operation->httpMethod(),
+                $path,
+                is_string($payload) ? $payload : '',
+                $query
+            )->getBody(),
             Operation::EXEC => $this->execPath($path, $query),
             Operation::ATTACH => $this->attachPath($path, $payload, $query),
             Operation::APPLY => $this->applyPath($path, $payload, $query),

--- a/src/Traits/Cluster/MakesHttpCalls.php
+++ b/src/Traits/Cluster/MakesHttpCalls.php
@@ -156,8 +156,7 @@ trait MakesHttpCalls
         $json = @json_decode($response->getBody(), true);
 
         // If the output is not JSONable, return the response itself.
-        // This can be encountered in case of a pod log request, for example,
-        // where the data returned are just console logs.
+        // This can be encountered when an endpoint returns plain-text output.
 
         if (! $json) {
             return (string) $response->getBody();

--- a/tests/KubernetesClusterTest.php
+++ b/tests/KubernetesClusterTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace RenokiCo\PhpK8s\Test;
+
+use GuzzleHttp\Psr7\Response;
+use Psr\Http\Message\ResponseInterface;
+use RenokiCo\PhpK8s\Enums\Operation;
+use RenokiCo\PhpK8s\Kinds\K8sPod;
+use RenokiCo\PhpK8s\KubernetesCluster;
+
+class KubernetesClusterTest extends TestCase
+{
+    public function test_log_operations_return_raw_json_logs_as_strings(): void
+    {
+        $expectedLogs = '{"status":200,"message":"ok","container":{"size":123}}';
+
+        $cluster = new class('http://127.0.0.1:8080', new Response(200, [], $expectedLogs)) extends KubernetesCluster
+        {
+            public function __construct(?string $url, private readonly ResponseInterface $response)
+            {
+                parent::__construct($url);
+            }
+
+            public function call(string $method, string $path, string $payload = '', array $query = ['pretty' => 1], array $options = []): ResponseInterface
+            {
+                return $this->response;
+            }
+        };
+
+        $result = $cluster
+            ->setResourceClass(K8sPod::class)
+            ->runOperation(Operation::LOG, '/api/v1/namespaces/default/pods/example/log', '');
+
+        $this->assertSame($expectedLogs, $result);
+        $this->assertIsString($result);
+    }
+
+    public function test_non_log_operations_still_hydrate_resources_from_json(): void
+    {
+        $cluster = new class('http://127.0.0.1:8080', new Response(200, [], '{"kind":"Pod","metadata":{"name":"example"}}')) extends KubernetesCluster
+        {
+            public function __construct(?string $url, private readonly ResponseInterface $response)
+            {
+                parent::__construct($url);
+            }
+
+            public function call(string $method, string $path, string $payload = '', array $query = ['pretty' => 1], array $options = []): ResponseInterface
+            {
+                return $this->response;
+            }
+        };
+
+        $result = $cluster
+            ->setResourceClass(K8sPod::class)
+            ->runOperation(Operation::GET, '/api/v1/namespaces/default/pods/example', '');
+
+        $this->assertInstanceOf(K8sPod::class, $result);
+        $this->assertSame('example', $result->getName());
+    }
+}

--- a/tests/KubernetesClusterTest.php
+++ b/tests/KubernetesClusterTest.php
@@ -32,7 +32,6 @@ class KubernetesClusterTest extends TestCase
             ->runOperation(Operation::LOG, '/api/v1/namespaces/default/pods/example/log', '');
 
         $this->assertSame($expectedLogs, $result);
-        $this->assertIsString($result);
     }
 
     public function test_non_log_operations_still_hydrate_resources_from_json(): void


### PR DESCRIPTION
## Summary
Fix log operations to always return the raw response body instead of hydrating JSON-looking log payloads into resource objects.

## Root Cause
`runOperation(Operation::LOG, ...)` stopped special-casing log responses and started routing them through the generic JSON hydration path. When a pod log body contained valid JSON, `php-k8s` would hydrate it into the current resource class, such as `K8sPod`, instead of returning the log text. That broke callers expecting `logs()` and `containerLogs()` to return strings.

## Changes
- restore raw-body handling for `Operation::LOG` in `KubernetesCluster::runOperation()`
- add a regression test proving JSON log payloads are still returned as strings
- add a companion assertion proving non-log JSON operations still hydrate normally

## Validation
- `vendor/bin/phpunit --no-coverage tests/KubernetesClusterTest.php`

## Impact
This preserves the intended Kubernetes pod log semantics for callers that consume structured JSON logs while keeping normal resource hydration unchanged.