### PR TITLE
fix: coerce empty maps structurally instead of corrupting string payloads

### DIFF
--- a/src/Kinds/K8sResource.php
+++ b/src/Kinds/K8sResource.php
@@ -145,21 +145,49 @@ class K8sResource implements Arrayable, Jsonable
     }
 
     /**
-     * Convert the object to its JSON representation, but
-     * escaping [] for {}. Optionally, you can specify
+     * Convert the object to its JSON representation, coercing empty
+     * map fields from [] to {}. Optionally, you can specify
      * the Kind attribute to replace.
-     *
-     * @return string
      */
     public function toJsonPayload(?string $kind = null): string|false
     {
-        $attributes = $this->toJson(JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES, $kind);
+        $coerced = $this->coerceEmptyArraysToObjects($this->toArray($kind));
 
-        $attributes = str_replace(': []', ': {}', $attributes);
+        return json_encode($coerced, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+    }
 
-        $attributes = str_replace('"allowedTopologies": {}', '"allowedTopologies": []', $attributes);
-        $attributes = str_replace('"mountOptions": {}', '"mountOptions": []', $attributes);
-        $attributes = str_replace('"accessModes": {}', '"accessModes": []', $attributes);
+    /**
+     * Kubernetes map fields are encoded by PHP's json_encode as `[]` when empty,
+     * but the API expects `{}` for objects. Walk the decoded structure and convert
+     * every empty array into an empty object so the byte sequence is only ever
+     * changed at structural positions — never inside string scalars (which would
+     * corrupt embedded scripts such as `glob(...) ?: []`).
+     *
+     * A handful of genuine list fields must stay as `[]` even when empty; those
+     * keys are exempted by name at any nesting depth.
+     *
+     * @param  array<array-key, mixed>  $attributes
+     * @return array<array-key, mixed>
+     */
+    protected function coerceEmptyArraysToObjects(array $attributes): array
+    {
+        $emptyArrayLists = ['allowedTopologies', 'mountOptions', 'accessModes'];
+
+        foreach ($attributes as $key => $value) {
+            if (! is_array($value)) {
+                continue;
+            }
+
+            if ($value === []) {
+                if (! in_array($key, $emptyArrayLists, true)) {
+                    $attributes[$key] = (object) [];
+                }
+
+                continue;
+            }
+
+            $attributes[$key] = $this->coerceEmptyArraysToObjects($value);
+        }
 
         return $attributes;
     }

--- a/tests/JsonPayloadTest.php
+++ b/tests/JsonPayloadTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace RenokiCo\PhpK8s\Test;
+
+use RenokiCo\PhpK8s\K8s;
+
+class JsonPayloadTest extends TestCase
+{
+    public function test_string_values_containing_empty_array_literal_are_not_corrupted()
+    {
+        $container = K8s::container()
+            ->setName('backup')
+            ->setImage('public.ecr.aws/docker/library/php', '8.4')
+            ->setCommand(['php', '-r', 'foreach (glob("/x/*") ?: [] as $file) { echo $file; }']);
+
+        $pod = $this->cluster->pod()
+            ->setName('backup')
+            ->setContainers([$container]);
+
+        $job = $this->cluster->job()
+            ->setName('backup')
+            ->setTemplate($pod);
+
+        $payload = $job->toJsonPayload();
+        $decoded = json_decode($payload, true);
+
+        $command = $decoded['spec']['template']['spec']['containers'][0]['command'][2];
+
+        $this->assertSame('foreach (glob("/x/*") ?: [] as $file) { echo $file; }', $command);
+        $this->assertStringNotContainsString('?: {}', $payload);
+    }
+
+    public function test_generic_colon_space_bracket_string_is_preserved()
+    {
+        $container = K8s::container()
+            ->setName('echo')
+            ->setImage('public.ecr.aws/docker/library/busybox')
+            ->setCommand(['/bin/sh', '-c', 'echo arr: [] done']);
+
+        $pod = $this->cluster->pod()
+            ->setName('echo')
+            ->setContainers([$container]);
+
+        $decoded = json_decode($pod->toJsonPayload(), true);
+
+        $this->assertSame('echo arr: [] done', $decoded['spec']['containers'][0]['command'][2]);
+    }
+
+    public function test_non_empty_list_arrays_stay_lists()
+    {
+        $container = K8s::container()
+            ->setName('echo')
+            ->setImage('public.ecr.aws/docker/library/busybox')
+            ->setCommand(['/bin/sh', '-c', 'true']);
+
+        $pod = $this->cluster->pod()
+            ->setName('echo')
+            ->setContainers([$container]);
+
+        $decoded = json_decode($pod->toJsonPayload(), true);
+
+        $this->assertTrue(array_is_list($decoded['spec']['containers']));
+        $this->assertCount(1, $decoded['spec']['containers']);
+    }
+
+    public function test_empty_map_fields_are_coerced_to_objects()
+    {
+        $configMap = $this->cluster->configmap()
+            ->setName('settings')
+            ->setLabels([])
+            ->setData([]);
+
+        $payload = $configMap->toJsonPayload();
+
+        $this->assertStringContainsString('"data": {}', $payload);
+        $this->assertStringContainsString('"labels": {}', $payload);
+    }
+
+    public function test_exempted_list_fields_stay_empty_arrays()
+    {
+        $storageClass = $this->cluster->storageClass()
+            ->setName('standard')
+            ->setProvisioner('csi.example.com');
+
+        $storageClass->setAttribute('mountOptions', []);
+        $storageClass->setAttribute('allowedTopologies', []);
+        $storageClass->setAttribute('accessModes', []);
+
+        $payload = $storageClass->toJsonPayload();
+
+        $this->assertStringContainsString('"mountOptions": []', $payload);
+        $this->assertStringContainsString('"allowedTopologies": []', $payload);
+        $this->assertStringContainsString('"accessModes": []', $payload);
+    }
+
+    public function test_nested_empty_map_deep_in_spec_is_coerced()
+    {
+        $container = K8s::container()
+            ->setName('echo')
+            ->setImage('public.ecr.aws/docker/library/busybox')
+            ->setCommand(['/bin/sh', '-c', 'true']);
+
+        $pod = $this->cluster->pod()
+            ->setName('echo')
+            ->setContainers([$container]);
+
+        $pod->setAttribute('spec.nodeSelector', []);
+
+        $payload = $pod->toJsonPayload();
+
+        $this->assertStringContainsString('"nodeSelector": {}', $payload);
+    }
+}


### PR DESCRIPTION
## The bug

`K8sResource::toJsonPayload()` coerced empty PHP arrays (`[]`) into empty JSON objects (`{}`) for Kubernetes map fields using a blind global string replace over the **entire** JSON-encoded payload:

```php
$attributes = str_replace(': []', ': {}', $attributes);
```

Because this operates on the raw JSON string, it also rewrites the `: []` byte sequence wherever it appears **inside string values** — not just at structural map positions. Container `command` arrays that embed inline scripts are corrupted.

## Repro

```php
$container = K8s::container()
    ->setName('backup')
    ->setImage('php', '8.4')
    ->setCommand(['php', '-r', 'foreach (glob("/x/*") ?: [] as $file) { echo $file; }']);

$job = $cluster->job()->setName('backup')->setTemplate(
    $cluster->pod()->setName('backup')->setContainers([$container])
);

$cmd = json_decode($job->toJsonPayload(), true)['spec']['template']['spec']['containers'][0]['command'][2];
// Before: foreach (glob("/x/*") ?: {} as $file) { echo $file; }   <-- PHP parse error
// After:  foreach (glob("/x/*") ?: [] as $file) { echo $file; }
```

The PHP expression `glob(...) ?: []` json-encodes as `?: []` inside the command string and gets rewritten to `?: {}`, which is a syntax error (`unexpected token "{"`).

## The fix

Replace the blind string replace with a **structure-aware** coercion. Instead of rewriting the encoded string, walk the resource attribute tree *before* encoding and convert empty-array nodes to empty objects. String scalars are leaves in the tree and are left byte-identical, so embedded scripts are never touched:

```php
$coerced = $this->coerceEmptyArraysToObjects($this->toArray($kind));
return json_encode($coerced, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
```

The recursive walk preserves the exact prior semantics: every empty array in the structure becomes `{}`, with the same three genuine list fields (`allowedTopologies`, `mountOptions`, `accessModes`) exempted by key name at any depth — previously handled by follow-up `str_replace` calls that re-inverted them. The public contract of `toJsonPayload()` is unchanged.

## Impact on Appwrite Edge

Appwrite Edge provisions dedicated-database backup Jobs whose containers run inline `php -r` maintenance scripts containing `glob(...) ?: []`. With the old coercion, every such Job was serialized with corrupted command strings and crash-looped on startup with `Parse error: syntax error, unexpected token "{"`, breaking dedicated-database backups in production. This fix makes those Jobs serialize correctly while preserving all existing empty-map behavior.

## Tests

Added `tests/JsonPayloadTest.php`:
- string values containing `?: []` (and `: []` generally) serialize byte-identical — fails on the old code, passes now
- empty `data`/`labels` maps still coerce to `{}`
- the three exempted list fields stay `[]`
- nested empty maps deep in `spec` coerce to `{}`
- non-empty list arrays stay lists

The two string-corruption tests fail against the unfixed method and pass with the fix; the full suite shows no new failures (remaining errors are pre-existing and require a live cluster / `ext-yaml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)